### PR TITLE
Add Safari 11.1 to browser support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uppie(document.querySelector('#file-input'), function (event, formData, files) {
 | Firefox | yes                   | yes           | yes (50+)            | yes (50+)    |
 | Chrome  | yes                   | yes           | yes (29+)            | yes (29+)    |
 | Edge    | yes                   | yes           | yes (13+)            | yes (14+)    |
-| Safari  | yes                   | yes           | no                   | no           |
+| Safari  | yes                   | yes           | yes (11.1+)          | yes (11.1+)  |
 
 ## Notes
 


### PR DESCRIPTION
Safari 11.1 supports directory uploading and thus works with this library.

https://caniuse.com/#feat=input-file-directory

I also tested it myself ☺️ 