### PR TITLE
Fix file drag-n-drop for Chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/uppie.js
+++ b/uppie.js
@@ -52,7 +52,7 @@
       node.addEventListener("drop", function(event) {
         event.preventDefault();
         var dt = event.dataTransfer;
-        if (dt.items && dt.items.length && "webkitGetAsEntry" in dt.items[0]) {
+        if (dt.items && dt.items.length && "webkitGetAsEntry" in dt.items[0] && dt.items[0].webkitGetAsEntry()) {
           entriesApi(dt.items, opts, cb.bind(null, event));
         } else if ("getFilesAndDirectories" in dt) {
           newDirectoryApi(dt, opts, cb.bind(null, event));


### PR DESCRIPTION
Hello @silverwind -

I am using [Cypress](https://www.npmjs.com/package/cypress) and [cypress-file-upload](https://www.npmjs.com/package/cypress-file-upload#usage) under Chrome to test our application that uses [uppie](https://www.npmjs.com/package/uppie).

`cypress-file-upload` creates and populates a [DataTransfer](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer) object that `uppie` consumes.

In Chrome (Version 80.0.3987.149 (Official Build) (64-bit)), `uppie` ends up ignoring the `drop` because `dt.items[0].webkitGetAsEntry()` returns `null` [here](https://github.com/silverwind/uppie/blob/master/uppie.js#L143-L144).

Here is some code that shows this:

```javascript
let dataTransfer = new DataTransfer();
let dataTransferItem = dataTransfer.items.add(new File(['abc'], 'ABC.txt'));

let currentTest = '"webkitGetAsEntry" in dataTransfer.items[0]'
let additionalTest = 'dataTransfer.items[0].webkitGetAsEntry()'

console.log(`${currentTest}: ${eval(currentTest)}`)
console.log(`${additionalTest}: ${eval(additionalTest)}`)
```
which results in the following under Chrome (Version 80.0.3987.149 (Official Build) (64-bit)):
```
currentTest ["webkitGetAsEntry" in dataTransfer.items[0]]: true
additionalTest [dataTransfer.items[0].webkitGetAsEntry()]: null
```
In Firefox (74.0.1 (64-bit)), webkitGetAsEntry is defined:
```
currentTest ["webkitGetAsEntry" in dataTransfer.items[0]]: true
additionalTest [dataTransfer.items[0].webkitGetAsEntry()]: [object FileSystemFileEntry]
```
In Safari (Version 13.0.5 (15608.5.11)) - there is no DataTransfer() constructor:
```
TypeError: function is not a constructor (evaluating 'new DataTransfer()')
```
In Edge (latest version):
```
currentTest ["webkitGetAsEntry" in dataTransfer.items[0]]: true
additionalTest [dataTransfer.items[0].webkitGetAsEntry()]: null
```

To get my integration tests working under Chrome in Cypress, either cypress-file-upload needs to delete or implement the `webkitGetAsEntry` function if its missing (Chrome), or uppies conditional test for calling `entriesApi()` or `arrayApi()` needs to change (or I can look for other packages.)

Is there a case where multiple `DataTransferItem`'s can exist, and only some have non-null `webkitGetAsEntry()` responses?

If not, could you consider this change?
