### PR TITLE
Support `window` and `document` as a dropzone

### DIFF
--- a/uppie.js
+++ b/uppie.js
@@ -34,7 +34,7 @@
   };
 
   function watch(node, opts, cb) {
-    if (node.tagName.toLowerCase() === "input" && node.type === "file") {
+    if (node.tagName && node.tagName.toLowerCase() === "input" && node.type === "file") {
       node.addEventListener("change", function(event) {
         var t = event.target;
         if (t.files && t.files.length) {


### PR DESCRIPTION
This patch checks if `node` has `tagName` property so `document` and `window` objects can also be used as a dropzone target.